### PR TITLE
Add domain selection capabilities for ROS 2

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,8 +29,7 @@ Aztarna's ROS2 and ROS-Industrial modules are an effort part of the RedROS-I and
   * Publishable topics.
   * Subscriptable topics.
   * Executable services.
-  * Readable parameters.
-  
+  * Readable parameters.  
   
 ### For ROS2 **(Funded under the [ROSIN project](http://rosin-project.eu/))**
 * A list of ROS2 nodes present in each communication domains.
@@ -144,6 +143,18 @@ aztarna -t ROS -p 11311-11500 -a 115.129.241.241
 
 ```bash
 aztarna -t ROS -p 11311,11312,11313 -a 115.129.241.241
+```
+
+### Run the code with ROS 2 (example exploring all ranges, 0-232)
+
+```bash
+aztarna -t ROS2
+```
+
+### Run the code with ROS 2 with `ROS_DOMAIN_ID=15`
+
+```bash
+aztarna -t ROS2 -d 15
 ```
 
 ### Run the code (example piping directly from zmap):

--- a/aztarna/cmd.py
+++ b/aztarna/cmd.py
@@ -31,6 +31,7 @@ def main():
     parser.add_argument('-o', '--out_file', help='Output file for the results')
     parser.add_argument('-e', '--extended', help='Extended scan of the hosts', action='store_true')
     parser.add_argument('-r', '--rate', help='Maximum simultaneous network connections', default=100, type=int)
+    parser.add_argument('-d', '--domain', help='ROS 2 DOMAIN ID (ROS_DOMAIN_ID environmental variable). Only applies to ROS 2.', type=int)
     parser.add_argument('--shodan', help='Use shodan for the scan types that support it.', action='store_true')
     parser.add_argument('--api-key', help='Shodan API Key')
     argcomplete.autocomplete(parser)
@@ -80,6 +81,7 @@ def main():
 
         scanner.extended = args.extended
         scanner.rate = args.rate
+        scanner.domain = args.domain
         scanner.scan()
 
         if args.out_file:

--- a/aztarna/commons.py
+++ b/aztarna/commons.py
@@ -19,6 +19,7 @@ class RobotAdapter:
         self.input = False
         self._rate = 1000
         self.semaphore = asyncio.Semaphore(self._rate)
+        self.domain = None
 
     @property
     def rate(self):

--- a/aztarna/industrialrouters/scanner.py
+++ b/aztarna/industrialrouters/scanner.py
@@ -3,7 +3,7 @@
 """
 Industrial routers scanner module.
 
-:author: Gorka Olalde Mendia(@olaldiko), Xabier Perez Baskaran(@xabierpb)
+
 """
 
 import asyncio

--- a/aztarna/industrialrouters/scanner.py
+++ b/aztarna/industrialrouters/scanner.py
@@ -3,7 +3,7 @@
 """
 Industrial routers scanner module.
 
-
+:author Alias Robotics SL (https://aliasrobotics.com)
 """
 
 import asyncio

--- a/aztarna/ros/ros/helpers.py
+++ b/aztarna/ros/ros/helpers.py
@@ -3,7 +3,7 @@
 """
 ROS Scanner helper module.
 
-
+:author Alias Robotics SL (https://aliasrobotics.com)
 """
 from aztarna.ros.commons import BaseNodeROS, BaseNodeROS, BaseServiceROS, BaseHostROS
 

--- a/aztarna/ros/ros/helpers.py
+++ b/aztarna/ros/ros/helpers.py
@@ -3,7 +3,7 @@
 """
 ROS Scanner helper module.
 
-:author: Gorka Olalde Mendia(@olaldiko), Xabier Perez Baskaran(@xabierpb)
+
 """
 from aztarna.ros.commons import BaseNodeROS, BaseNodeROS, BaseServiceROS, BaseHostROS
 

--- a/aztarna/ros/ros/scanner.py
+++ b/aztarna/ros/ros/scanner.py
@@ -3,7 +3,7 @@
 """
 ROS Scanner module.
 
-:author: Gorka Olalde Mendia(@olaldiko), Xabier Perez Baskaran(@xabierpb)
+
 """
 import asyncio
 import aiohttp

--- a/aztarna/ros/ros/scanner.py
+++ b/aztarna/ros/ros/scanner.py
@@ -2,6 +2,8 @@
 # -*- coding: utf-8 -*-
 """
 ROS Scanner module.
+
+:author Alias Robotics SL (https://aliasrobotics.com)
 """
 import asyncio
 import aiohttp

--- a/aztarna/ros/ros/scanner.py
+++ b/aztarna/ros/ros/scanner.py
@@ -2,8 +2,6 @@
 # -*- coding: utf-8 -*-
 """
 ROS Scanner module.
-
-
 """
 import asyncio
 import aiohttp

--- a/aztarna/ros/ros2/scanner.py
+++ b/aztarna/ros/ros2/scanner.py
@@ -6,8 +6,10 @@ from aztarna.commons import RobotAdapter
 from aztarna.ros.ros2.helpers import ROS2Node, ROS2Host, ROS2Topic, ROS2Service, raw_topics_to_pyobj_list, \
     raw_services_to_pyobj_list
 
-max_ros_domain_id = 231
-
+# Max value of ROS_DOMAIN_ID
+#   See https://github.com/eProsima/Fast-RTPS/issues/223
+#   See https://answers.ros.org/question/318386/ros2-max-domain-id/
+max_ros_domain_id = 232
 
 class ROS2Scanner(RobotAdapter):
 
@@ -130,7 +132,20 @@ class ROS2Scanner(RobotAdapter):
             from rclpy.context import Context
         except ImportError:
             raise Exception('ROS2 needs to be installed and sourced to run ROS2 scans')
-        for i in range(0, max_ros_domain_id):
+        
+        # Explore the specified domain or all depending on the arguments provided (-d option)
+        # TODO: consider ranges (e.g. 1-5) if provided
+        domain_id_range_init = 0
+        domain_id_range_end = 5
+        domain_id_range = range(domain_id_range_init, domain_id_range_end+1)
+
+        if self.domain is not None:
+            domain_id_range = [self.domain]            
+        else:
+            print("Exploring ROS_DOMAIN_ID from: "+str(domain_id_range_init)+str(" to ")+str(domain_id_range_end))
+
+        for i in domain_id_range:
+            print("Exploring ROS_DOMAIN_ID: "+str(i))
             os.environ['ROS_DOMAIN_ID'] = str(i)
             rclpy.init()
             scanner_node = rclpy.create_node(self.scanner_node_name)

--- a/aztarna/ros/sros/helpers.py
+++ b/aztarna/ros/sros/helpers.py
@@ -3,7 +3,7 @@
 
 """
 SROS Scanner helpers classes module.
-
+:author Alias Robotics SL (https://aliasrobotics.com)
 """
 
 import asyncio

--- a/aztarna/ros/sros/helpers.py
+++ b/aztarna/ros/sros/helpers.py
@@ -3,7 +3,7 @@
 
 """
 SROS Scanner helpers classes module.
-:author: Gorka Olalde Mendia(@olaldiko), Xabier Perez Baskaran(@xabierpb)
+
 """
 
 import asyncio

--- a/aztarna/ros/sros/scanner.py
+++ b/aztarna/ros/sros/scanner.py
@@ -3,7 +3,7 @@
 """
 SROS Scanner module.
 
-
+:author Alias Robotics SL (https://aliasrobotics.com)
 """
 
 import asyncio

--- a/aztarna/ros/sros/scanner.py
+++ b/aztarna/ros/sros/scanner.py
@@ -3,7 +3,7 @@
 """
 SROS Scanner module.
 
-:author: Gorka Olalde Mendia(@olaldiko), Xabier Perez Baskaran(@xabierpb)
+
 """
 
 import asyncio

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from setuptools import setup
 
 setup(
     name='aztarna',
-    version='1.2.1',
+    version='1.2.2',
     packages=[
                 'aztarna',
                 'aztarna.ros',


### PR DESCRIPTION
Adds `-d` option, logic enabled only for ROS 2. Other `RobotAdapters` shouldn't be affected. Included also some additional user information when launching without an specific domain.

This PR also removes individual names from the code and points instead to https://github.com/aliasrobotics/aztarna/graphs/contributors where all contributions are available.